### PR TITLE
pass in workspace_name

### DIFF
--- a/apps/server/src/airbyte_api.js
+++ b/apps/server/src/airbyte_api.js
@@ -58,6 +58,7 @@ async function generateWidgetToken(externalUserId, allowedOrigin = null) {
             },
             body: JSON.stringify({
                 external_user_id: externalUserId,
+                workspace_name: externalUserId,
                 organization_id: process.env.SONAR_AIRBYTE_ORGANIZATION_ID,
                 allowed_origin: origin,
             })


### PR DESCRIPTION
we'll remove the external_user_id field and replace it with workspace_name.

Passing in both for now will allow us to do the rename without breaking the demo app